### PR TITLE
Fix token bug

### DIFF
--- a/src/ERC20VotesMintable.sol
+++ b/src/ERC20VotesMintable.sol
@@ -175,34 +175,24 @@ contract ERC20VotesMintable is
         // dont let people update rewards pool for same account
         if (from == to) return;
 
-        uint128 fromUnits = IRewardPool(rewardPool).getMemberUnits(from);
-        uint128 toUnits = IRewardPool(rewardPool).getMemberUnits(to);
-
         // update member units in the reward pool
-        // subtract from old account, add to new account
-
-        // double check for overflow before casting
-        // and scale back by 1e14 per https://docs.superfluid.finance/docs/protocol/distributions/guides/pools#about-member-units
+        // and scale back by 1e12 per https://docs.superfluid.finance/docs/protocol/distributions/guides/pools#about-member-units
         // gives someone with 1 token at least 1e6 units to work with
-        uint256 scaledUnits = amount / 1e12;
 
-        // todo investigate whether small token transfers can let someone transfer without transfering member units
-        if (scaledUnits == 0) revert INVALID_AMOUNT_FOR_MEMBER_UNITS();
-
-        if (scaledUnits > type(uint128).max) revert POOL_UNITS_OVERFLOW();
-        uint128 transferredUnits = uint128(scaledUnits);
-
-        // if minting from 0 address, don't subtract member units from 0x0
+        // if minting from 0 address, don't update member units
         if (from != address(0)) {
-            // shouldn't ever happen but to be safe
-            if (fromUnits < transferredUnits) revert POOL_UNITS_OVERFLOW();
-            IRewardPool(rewardPool).updateMemberUnits(from, fromUnits - transferredUnits);
+            uint256 rawBalance = balanceOf(from);
+            if (rawBalance > type(uint128).max) revert POOL_UNITS_OVERFLOW();
+            uint128 fromUnits = uint128(rawBalance / 1e12);
+            IRewardPool(rewardPool).updateMemberUnits(from, fromUnits);
         }
 
-        // if transferring to 0 address, don't add member units to 0x0
+        // if transferring to 0 address, don't update member units
         if (to != address(0)) {
-            if (toUnits + transferredUnits > type(uint128).max) revert POOL_UNITS_OVERFLOW();
-            IRewardPool(rewardPool).updateMemberUnits(to, toUnits + transferredUnits);
+            uint256 rawBalance = balanceOf(to);
+            if (rawBalance > type(uint128).max) revert POOL_UNITS_OVERFLOW();
+            uint128 toUnits = uint128(rawBalance / 1e12);
+            IRewardPool(rewardPool).updateMemberUnits(to, toUnits);
         } else {
             // burning tokens here since to is the 0 address
             // limitation of superfluid means that when total member units decrease, you must call `distributeFlow` again

--- a/src/ERC20VotesMintable.sol
+++ b/src/ERC20VotesMintable.sol
@@ -31,7 +31,6 @@ contract ERC20VotesMintable is
     address public rewardPool;
 
     error POOL_UNITS_OVERFLOW();
-    error INVALID_AMOUNT_FOR_MEMBER_UNITS();
 
     ///                                                          ///
     ///                          MODIFIERS                       ///

--- a/src/ERC20VotesMintable.sol
+++ b/src/ERC20VotesMintable.sol
@@ -180,17 +180,17 @@ contract ERC20VotesMintable is
 
         // if minting from 0 address, don't update member units
         if (from != address(0)) {
-            uint256 rawBalance = balanceOf(from);
-            if (rawBalance > type(uint128).max) revert POOL_UNITS_OVERFLOW();
-            uint128 fromUnits = uint128(rawBalance / 1e12);
+            uint256 units = balanceOf(from) / 1e12;
+            if (units > type(uint128).max) revert POOL_UNITS_OVERFLOW();
+            uint128 fromUnits = uint128(units);
             IRewardPool(rewardPool).updateMemberUnits(from, fromUnits);
         }
 
         // if transferring to 0 address, don't update member units
         if (to != address(0)) {
-            uint256 rawBalance = balanceOf(to);
-            if (rawBalance > type(uint128).max) revert POOL_UNITS_OVERFLOW();
-            uint128 toUnits = uint128(rawBalance / 1e12);
+            uint256 units = balanceOf(to) / 1e12;
+            if (units > type(uint128).max) revert POOL_UNITS_OVERFLOW();
+            uint128 toUnits = uint128(units);
             IRewardPool(rewardPool).updateMemberUnits(to, toUnits);
         } else {
             // burning tokens here since to is the 0 address

--- a/src/tcr/GeneralizedTCR.sol
+++ b/src/tcr/GeneralizedTCR.sol
@@ -560,7 +560,7 @@ abstract contract GeneralizedTCR is
         request.resolved = true;
         request.ruling = Party(_ruling);
 
-        emit ItemStatusChange(itemID, item.requests.length - 1, request.rounds.length - 1, true, true, item.status);
+        emit ItemStatusChange(itemID, item.requests.length - 1, request.rounds.length - 1, false, true, item.status);
 
         // Automatically withdraw first deposits and reimbursements (first round only).
         if (winner == Party.None) {


### PR DESCRIPTION
- Updates member units for ERC20 token holders based on their `balanceOf` not the amount passed in to the `afterTokenTransfer`

This way, we don't have to do math on small transfer amount, the integer rounding just happens atomically on the balance level for each account. 